### PR TITLE
Addition of PennCNB category

### DIFF
--- a/subject_files_status_for_dpdash.py
+++ b/subject_files_status_for_dpdash.py
@@ -153,5 +153,5 @@ def _is_scansheet(root:Path, subdir: str, suffix: str= None) -> bool:
 
 if __name__=='__main__':
     phoenix_files_status(pronet_phoenix_dir, pronet_status_dir)
-    # phoenix_files_status(prescient_phoenix_dir, prescient_status_dir)
+    phoenix_files_status(prescient_phoenix_dir, prescient_status_dir)
 

--- a/subject_files_status_for_dpdash.py
+++ b/subject_files_status_for_dpdash.py
@@ -44,8 +44,11 @@ def get_summary_from_phoenix(phoenix_dir: Path) -> pd.DataFrame:
     df['surveys'] = df.p.apply(
         lambda x: (_is_file(x, 'surveys', '*Pronet.json') or
                   _is_file(x, 'surveys', '*.csv')))
-    df['upenn_surveys'] = df.p.apply(
-        lambda x: _is_file(x, 'surveys', '*UPENN.json'))
+    
+    # PennCNB
+    df['cnb'] = df.p.apply(lambda x: _is_file(x, 'surveys', '*UPENN.json'))
+    df['cnb_ss'] = df.p.apply(lambda x: _is_file(x, 'surveys', '*.Run_sheet_PennCNB.csv'))
+    
 
     # eeg
     df['eeg'] = df.p.apply(lambda x: _is_file(x, 'eeg', '*zip'))

--- a/subject_files_status_for_dpdash.py
+++ b/subject_files_status_for_dpdash.py
@@ -47,7 +47,8 @@ def get_summary_from_phoenix(phoenix_dir: Path) -> pd.DataFrame:
     
     # PennCNB
     df['cnb'] = df.p.apply(lambda x: _is_file(x, 'surveys', '*UPENN.json'))
-    df['cnb_ss'] = df.p.apply(lambda x: _is_file(x, 'surveys', '*.Run_sheet_PennCNB.csv'))
+    df['cnb_ss'] = df.p.apply(lambda x: _is_scansheet(x, 'surveys', 
+        suffix='PennCNB'))
     
 
     # eeg
@@ -141,13 +142,16 @@ def _is_dir(root:Path, subdir: str, pattern: str) -> bool:
     return _get_dir_count(root, subdir, pattern) > 0
 
 
-def _is_scansheet(root:Path, subdir: str) -> bool:
+def _is_scansheet(root:Path, subdir: str, suffix: str= None) -> bool:
     '''check if there is a scan sheet for a datatype (subdir)'''
+    if not suffix:
+        suffix= subdir
+
     return _get_count(
-            root, subdir, f'{root.name}.*.Run_sheet_{subdir}.csv') > 0
+            root, subdir, f'{root.name}.*.Run_sheet_{suffix}.csv') > 0
 
 
 if __name__=='__main__':
     phoenix_files_status(pronet_phoenix_dir, pronet_status_dir)
-    phoenix_files_status(prescient_phoenix_dir, prescient_status_dir)
+    # phoenix_files_status(prescient_phoenix_dir, prescient_status_dir)
 


### PR DESCRIPTION
1. Omitted `upenn_surveys` column because that is vague. Instead, added `cnb` and `cnb_ss` columns. I have put them under `cnb` category in DPdash

2. Included a `suffix` argument in Kevin's helper `_is_scansheet()` to cover the case that PennCNB run sheets live in `surveys/` directory. Notably, all other run sheets live in the corresponding datatype directory.

3. The new DPdash looks like:

![image](https://user-images.githubusercontent.com/35086881/154359861-7ff3c3f6-87c8-42fe-a2b7-7dfae3e9dc2e.png)

