### PR TITLE
Generalize files status tracker to data root folder

### DIFF
--- a/dpimport_remote_data.sh
+++ b/dpimport_remote_data.sh
@@ -3,9 +3,9 @@
 export PATH=/data/predict/mongodb-linux-x86_64-rhel70-4.4.6/bin:$PATH
 
 
-if [ -z $HOST ] || [ -z $PORT ] || [ -z $state ] || [ -z $MONGO_PASS ] || [ -z $CONFIG ]
+if [ -z $HOST ] || [ -z $PORT ] || [ -z $state ] || [ -z $MONGO_PASS ] || [ -z $CONFIG ] || [ -z $NDA_ROOT ]
 then
-    echo Define HOST, PORT, state, MONGO_PASS, CONFIG and try again
+    echo Define HOST, PORT, state, MONGO_PASS, CONFIG, NDA_ROOT and try again
     exit 1
 fi
 
@@ -18,7 +18,7 @@ mongo --tls --tlsCAFile $state/ssl/ca/cacert.pem --tlsCertificateKeyFile $state/
 # import new collections
 source /data/pnl/soft/pnlpipe3/miniconda3/bin/activate && conda activate dpimport
 
-cd /data/predict/kcho/flow_test/
+cd $NDA_ROOT
 
 # metadata
 import.py -c /data/predict/dpimport/examples/$CONFIG files_metadata.csv

--- a/generate_files_status.sh
+++ b/generate_files_status.sh
@@ -3,21 +3,21 @@
 export PATH=/data/predict/utility/:$PATH
 NDA_ROOT=$1
 
-rm /data/predict/kcho/flow_test/files_metadata.csv
+rm ${NDA_ROOT}/files_metadata.csv
 
 # use pnlpipe3 environment to bypass the error below
 # https://gist.github.com/tashrifbillah/24efeec3219ba3c58c92adc419aac7be#gistcomment-4037001
-source /data/pnl/soft/pnlpipe3/miniconda3/bin/activate && conda activate pnlpipe3 && \
+source /data/pnl/soft/pnlpipe3/miniconda3/bin/activate base && conda activate pnlpipe3 && \
 subject_files_status_for_dpdash.py $NDA_ROOT && \
-cd $NDA_ROOT/Pronet_status && \
+cd ${NDA_ROOT}/Pronet_status && \
 project_files_status_for_dpdash.py ProNET ../files_metadata.csv *-flowcheck-day1to1.csv && \
 chmod g+w * && \
-cd $NDA_ROOT/Prescient_status && \
+cd ${NDA_ROOT}/Prescient_status && \
 project_files_status_for_dpdash.py PRESCIENT ../files_metadata.csv *-flowcheck-day1to1.csv && \
 chmod g+w *
 
 # export the above csv files to remote MongoDB server
 cd /data/predict/utility
-source .vault/.env.dpstage && ./dpimport_remote_data.sh
-source .vault/.env.rc-predict && ./dpimport_remote_data.sh
+# source .vault/.env.dpstage && ./dpimport_remote_data.sh
+# source .vault/.env.rc-predict && ./dpimport_remote_data.sh
 

--- a/generate_files_status.sh
+++ b/generate_files_status.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
 export PATH=/data/predict/utility/:$PATH
+NDA_ROOT=$1
 
 rm /data/predict/kcho/flow_test/files_metadata.csv
 
 # use pnlpipe3 environment to bypass the error below
 # https://gist.github.com/tashrifbillah/24efeec3219ba3c58c92adc419aac7be#gistcomment-4037001
 source /data/pnl/soft/pnlpipe3/miniconda3/bin/activate && conda activate pnlpipe3 && \
-subject_files_status_for_dpdash.py && \
-cd /data/predict/kcho/flow_test/Pronet_status && \
+subject_files_status_for_dpdash.py $NDA_ROOT && \
+cd $NDA_ROOT/Pronet_status && \
 project_files_status_for_dpdash.py ProNET ../files_metadata.csv *-flowcheck-day1to1.csv && \
 chmod g+w * && \
-cd /data/predict/kcho/flow_test/Prescient_status && \
+cd $NDA_ROOT/Prescient_status && \
 project_files_status_for_dpdash.py PRESCIENT ../files_metadata.csv *-flowcheck-day1to1.csv && \
 chmod g+w *
 

--- a/generate_files_status.sh
+++ b/generate_files_status.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
 export PATH=/data/predict/utility/:$PATH
-NDA_ROOT=$1
+if [ -z $1 ] || [ ! -d $1 ]
+then
+    echo "./generate_file_status.sh /path/to/nda_root/"
+    echo "Provide /path/to/nda_root/ and try again"
+    exit
+else
+    export NDA_ROOT=$1
+fi
+
 
 rm ${NDA_ROOT}/files_metadata.csv
 
@@ -19,5 +27,5 @@ chmod g+w *
 # export the above csv files to remote MongoDB server
 cd /data/predict/utility
 # source .vault/.env.dpstage && ./dpimport_remote_data.sh
-# source .vault/.env.rc-predict && ./dpimport_remote_data.sh
+source .vault/.env.rc-predict && ./dpimport_remote_data.sh
 

--- a/subject_files_status_for_dpdash.py
+++ b/subject_files_status_for_dpdash.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 import pandas as pd
 import numpy as np
-import re
+import re, sys
 from datetime import time, timedelta, datetime, date
 
 # sys.arv[1] is the NDA_ROOT folder

--- a/subject_files_status_for_dpdash.py
+++ b/subject_files_status_for_dpdash.py
@@ -9,7 +9,8 @@ import numpy as np
 import re
 from datetime import time, timedelta, datetime, date
 
-flow_test_root = Path('/data/predict/kcho/flow_test')
+# sys.arv[1] is the NDA_ROOT folder
+flow_test_root = Path(sys.argv[1])
 pronet_phoenix_dir = flow_test_root / 'Pronet/PHOENIX'
 prescient_phoenix_dir = flow_test_root / 'Prescient/PHOENIX'
 


### PR DESCRIPTION
Generalize `generate_file_status.sh` and `dpimport_remote_data.sh` so they can work on any data root folder