### PR TITLE
MRI Raw Data cell in the file tracker to ignore shim settings

### DIFF
--- a/subject_files_status_for_dpdash.py
+++ b/subject_files_status_for_dpdash.py
@@ -119,14 +119,13 @@ def check_mri_and_qqc_result(root: Path) -> int:
 
     # load QC result
     session_name = 'ses-' + ''.join(name_sections[2:]).split('.')[0]
-    qqc_dir = mri_qqc_root / ('sub-'+root.name) /session_name
+    qqc_dir = mri_qqc_root / f'sub-{root.name}' / session_name
     qc_summary = qqc_dir / '00_qc_summary.csv'
 
     labels_to_check = ['Series count',
                        'Volume slice number comparison',
                        'Image orientation in anat',
                        'Image orientation in others',
-                       'Shim settings',
                        'Bval comparison']
 
     if qc_summary.is_file():


### PR DESCRIPTION
According to Ofer's update to ignore a wrong shim settings from being highlighted in the file tracker view on DPDash, this PR removes `Shim settings` from the list of labels check in `check_mri_and_qqc_result` function.