### PR TITLE
feat: Add scripts for parsing .out and .err from redcap-import

### DIFF
--- a/parse_redcap_error.py
+++ b/parse_redcap_error.py
@@ -4,6 +4,10 @@ import sys
 from glob import glob
 from tqdm import tqdm
 
+# Example Usage:
+# python parse_redcap_error.py /path/to/redcap-import-<JOBID>-*.out
+# ./parse_redcap_error.py /path/to/redcap-import-<JOBID>-*.out
+
 def parse_file(file) -> tuple:
     """
     Parses a file and returns a tuple containing the file path and the number of HTTP 400 errors found in the file.

--- a/parse_redcap_error.py
+++ b/parse_redcap_error.py
@@ -2,20 +2,51 @@
 
 import sys
 from glob import glob
+from tqdm import tqdm
 
-files=glob(sys.argv[1])
+def parse_file(file) -> tuple:
+    """
+    Parses a file and returns a tuple containing the file path and the number of HTTP 400 errors found in the file.
+    Expects redcap-import-*-*.out files.
 
-for file in files:
+    Args:
+        file (str): The path to the file to be parsed.
 
-    with open(file) as f:
-        content=f.read().split('\n')
+    Returns:
+        tuple: A tuple containing the file path and the number of HTTP 400 errors found in the file.
+    """
+    try:
+        with open(file) as f:
+            content = f.read().split('\n')
+            error_count = 0
 
-    print('\033[92m','Parsing',file,'\033[0m')
+        for idx, line in enumerate(content):
+            if 'HTTP Status: 400' in line:
+                error_count += 1
 
-    for i,line in enumerate(content):
-        if 'HTTP Status: 400' in line:
-            print(content[i-1])
-            print(content[i+1])
-            print('')
-            print('')
+                print('')
+                print('\033[91m','Parsing',file,'\033[0m')
+                print(content[idx-1].strip())
+                print(content[idx+1])
+                print('')
+
+    except Exception as e:
+        print(f"Error parsing file {file}: {e}")
+        error_count = -1
+
+    return (file, error_count)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} <path/and*pattern.*>')
+        sys.exit(1)
+
+    files=glob(sys.argv[1])
+
+    results = list(tqdm(map(parse_file, files), total=len(files)))
+
+    print('Parsed ' +  str(len(files)) + ' files matching ' + sys.argv[1])
+    for file, error_count in results:
+        if error_count > 0:
+            print(f"{file}: {error_count} errors")
         

--- a/parse_redcap_errors_err.py
+++ b/parse_redcap_errors_err.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+import sys
+import re
+from glob import glob
+from tqdm import tqdm
+
+def parse_file(file_path) -> tuple:
+    """
+    Parses a file for errors and returns the file path and the number of errors found.
+    Expects redcap-import-*-*.err files.
+
+    Args:
+        file_path (str): The path to the file to parse.
+
+    Returns:
+        tuple: A tuple containing the file path and the number of errors found.
+    """
+    try:
+        with open(file_path) as file:
+            content = file.read().split('\n')
+            error_count = 0
+
+        idx = 0
+        while idx < len(content):
+            line = content[idx]
+            # If the line contains 'Traceback (most recent call last):', then there was an error
+            if 'Traceback (most recent call last):' in line:
+                error_count += 1
+
+                print('')
+                print('\033[91m','Parsing',file,'\033[0m')
+                # Print the line before the error
+                print(content[idx-1])
+                
+                # Skip to the next line that contains a .csv file name
+                while not re.match(r'.*\.csv.*', content[idx+1]):
+                    print(content[idx+1])
+                    idx += 1                
+
+                # Print the line after the error, with a csv file name
+                print(content[idx+1])
+                print('')
+
+            idx += 1
+
+    except Exception as e:
+        print(f"Error parsing file {file_path}: {e}")
+        error_count = -1
+
+    return (file_path, error_count)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python {__file__} <path/and*pattern.*>')
+        sys.exit(1)
+
+    files = glob(sys.argv[1])
+    results = [parse_file(file) for file in tqdm(files)]
+
+    # Print a brief summary of the results
+
+    print(f"\nParsed {len(files)} files matching {sys.argv[1]}")
+
+    errors_found = False
+    errors_files_count = 0
+    errors_found_count = 0
+    for file, file_error_count in results:
+        if file_error_count > 0:
+            errors_found = True
+            errors_files_count += 1
+            errors_found_count += file_error_count
+            print(f"{file}: {file_error_count} errors")
+
+    print('\n')
+    if not errors_found:
+        print('\033[92m' + 'No errors found!' + '\033[0m')
+    else:
+        print('\033[91m' + f'{errors_files_count} files with errors found!\n# of errors: {errors_found_count}' + '\033[0m')

--- a/parse_redcap_errors_err.py
+++ b/parse_redcap_errors_err.py
@@ -5,6 +5,10 @@ import re
 from glob import glob
 from tqdm import tqdm
 
+# Example Usage:
+# python parse_redcap_errors_err.py /path/to/redcap-import-<JOBID>-*.err
+# ./parse_redcap_errors_err.py /path/to/redcap-import-<JOBID>-*.err
+
 def parse_file(file_path) -> tuple:
     """
     Parses a file for errors and returns the file path and the number of errors found.


### PR DESCRIPTION
Builds on top of existing 'parse_redcap_error.py' to only print files that failed with HTTP Code 400. Adds parse_redcap_errors_err.py that similarly parses '*.out' files from redcap import.